### PR TITLE
feat: make RPC and Indexer URLs configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_MEMPOOL_RPC=https://mempool.staging.midl.xyz
+NEXT_PUBLIC_INDEXER_URL=https://api-regtest-midl.xverse.app
+NEXT_PUBLIC_EVM_RPC=https://rpc.staging.midl.xyz

--- a/apps/web/src/app/(app-layout)/layout.tsx
+++ b/apps/web/src/app/(app-layout)/layout.tsx
@@ -40,8 +40,13 @@ const Wallet = () => {
           networkConfig: {
             name: 'MIDL Regtest',
             network: network.id,
-            rpcUrl: 'https://mempool.regtest.midl.xyz/api',
-            indexerUrl: 'https://api-regtest-midl.xverse.app',
+            rpcUrl: `${
+              process.env.NEXT_PUBLIC_MEMPOOL_RPC ||
+              'https://mempool.regtest.midl.xyz'
+            }/api`,
+            indexerUrl:
+              process.env.NEXT_PUBLIC_INDEXER_URL ||
+              'https://api-regtest-midl.xverse.app',
           },
         });
       }}

--- a/apps/web/src/widgets/app-menu/ui/MobileAppMenu.tsx
+++ b/apps/web/src/widgets/app-menu/ui/MobileAppMenu.tsx
@@ -2,8 +2,6 @@
 
 import { Dialog, DialogContent, DialogOverlay } from '@/shared';
 import { AppMenuList } from '@/widgets';
-import { xverseConnector } from '@midl-xyz/midl-js-connectors';
-import { useAddNetwork, useConfig } from '@midl-xyz/midl-js-react';
 import { ConnectButton } from '@midl-xyz/satoshi-kit';
 import { X } from 'lucide-react';
 import Image from 'next/image';
@@ -12,30 +10,7 @@ import { Stack, VStack } from '~/styled-system/jsx';
 import MenuIcon from '../assets/menu.svg';
 
 const Wallet: FC<{ onClick: () => void }> = ({ onClick }) => {
-  const { addNetworkAsync } = useAddNetwork();
-  const { network } = useConfig();
-
-  return (
-    <ConnectButton
-      beforeConnect={async (connectorId) => {
-        // if (connectorId !== xverseConnector().id) {
-        //   onClick();
-        //   return;
-        // }
-
-        // await addNetworkAsync({
-        //   connectorId,
-        //   networkConfig: {
-        //     name: 'MIDL Regtest',
-        //     network: network.id,
-        //     rpcUrl: 'https://mempool.regtest.midl.xyz/api',
-        //     indexerUrl: 'https://api-regtest-midl.xverse.app',
-        //   },
-        // });
-        onClick();
-      }}
-    />
-  );
+  return <ConnectButton beforeConnect={onClick} />;
 };
 
 export const MobileAppMenu = () => {

--- a/apps/web/src/widgets/swap-form/ui/SwapForm.tsx
+++ b/apps/web/src/widgets/swap-form/ui/SwapForm.tsx
@@ -51,8 +51,13 @@ const Wallet = () => {
           networkConfig: {
             name: 'MIDL Regtest',
             network: network.id,
-            rpcUrl: 'https://mempool.regtest.midl.xyz/api',
-            indexerUrl: 'https://api-regtest-midl.xverse.app',
+            rpcUrl: `${
+              process.env.NEXT_PUBLIC_MEMPOOL_RPC ||
+              'https://mempool.regtest.midl.xyz'
+            }/api`,
+            indexerUrl:
+              process.env.NEXT_PUBLIC_INDEXER_URL ||
+              'https://api-regtest-midl.xverse.app',
           },
         });
       }}


### PR DESCRIPTION
- Updated `SwapForm` and `layout` to use `NEXT_PUBLIC_MEMPOOL_RPC` and `NEXT_PUBLIC_INDEXER_URL` for URLs with fallback to defaults.
- Added `.env.example` to provide examples for environment variable configuration.
- Adjusted commented-out code in `MobileAppMenu` for consistency with updates.