### PR TITLE
chore/add token button

### DIFF
--- a/apps/web/src/features/runes/ui/add-rune-dialog/AddRuneDialog.tsx
+++ b/apps/web/src/features/runes/ui/add-rune-dialog/AddRuneDialog.tsx
@@ -185,14 +185,14 @@ export const AddRuneDialog = ({ onClose, ...rest }: AddRuneDialogProps) => {
                   textStyle: 'h3',
                 })}
               >
-                Add rune to the MIDL ecosystem
+                Add token to the MIDL ecosystem
               </h1>
             </DialogTitle>
 
             <TokenLogo runeId={rune?.id} size={12} />
 
-            <p>
-              To add the rune, please transfer the minimum amount (e.g 1{' '}
+            <p style={{ wordBreak: 'break-all' }}>
+              To add the token, please transfer the minimum amount (e.g 1{' '}
               {rune?.symbol}) of <b>{rune?.spaced_name}</b> and validator's fee
               ({formatUnits(BigInt(edictFee ?? 546), 8)} BTC) to the following
               address:
@@ -205,7 +205,7 @@ export const AddRuneDialog = ({ onClose, ...rest }: AddRuneDialogProps) => {
               disabled={isTransactionBeingFormed}
               onClick={onConfirm}
             >
-              {isTransactionBeingFormed ? 'Confirming...' : 'Add rune'}
+              {isTransactionBeingFormed ? 'Confirming...' : 'Add token'}
             </Button>
           </div>
         )}

--- a/apps/web/src/features/token/ui/token-select/TokenSelect.tsx
+++ b/apps/web/src/features/token/ui/token-select/TokenSelect.tsx
@@ -212,19 +212,40 @@ export const TokenSelect = ({ onSelect }: TokenSelectProps) => {
           {rune?.id && customToken.symbol === 'N/A' && (
             <div className={vstack({ gap: 2, alignItems: 'start' })}>
               <div>Not added to the MIDL ecosystem yet. </div>
-              <div className={hstack()}>
-                <TokenLogo runeId={rune.id} size={12} />
-                <div className={vstack({ gap: 0, alignItems: 'start' })}>
-                  <div>{rune.spaced_name}</div>
-                  <div>{rune.symbol}</div>
+              <div
+                className={hstack({
+                  justifyContent: 'space-between',
+                  width: 'full',
+                })}
+              >
+                <div className={hstack({ gap: 2, justifyContent: 'start' })}>
+                  <TokenLogo runeId={rune.id} size={12} />
+                  <div
+                    className={vstack({
+                      gap: 0,
+                      justifyContent: 'start',
+                      alignItems: 'start',
+                      maxWidth: '100px',
+                    })}
+                  >
+                    <div
+                      style={{
+                        width: 120,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {rune.spaced_name}
+                    </div>
+                    <div>{rune.symbol}</div>
+                  </div>
                 </div>
-
                 <Button
                   onClick={() => {
                     open(rune.id);
                   }}
                 >
-                  Add rune
+                  Add token
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
### CHANGELOG


[https://www.notion.so/replace-add-rune-button-with-add-token-25d362757c9880f3bee1fd70cfc4586f?v=254362757c98819b8dbc000cab182bf2&source=copy_link ](url)

**apps/web/src/features/runes/ui/add-rune-dialog/AddRuneDialog.tsx**
- replaced rune with token in the text;
- added mobile responsiveness;

**apps/web/src/features/token/ui/token-select/TokenSelect.tsx**
- replaced rune with token in the button;
- aligned add token button to right side;
- fixed add token button overflow beyond container boundaries;
- truncated long token names with ellipsis.


