### PR TITLE
feat: add community token pairs to Pairs widget

### DIFF
--- a/apps/web/src/widgets/pairs/ui/Pairs.tsx
+++ b/apps/web/src/widgets/pairs/ui/Pairs.tsx
@@ -6,6 +6,10 @@ import { PairItem } from '@/widgets/pairs/ui/pair/PairItem';
 import { getAddress } from 'viem';
 import { css } from '~/styled-system/css';
 
+const COMMUNITY_PAIRS = [
+  ['MIDLRUNESTABLECOIN', 'WARTOK'],
+  ['WARTOK', 'BTC'],
+];
 export const Pairs = () => {
   const tokens = [
     ['LOBOTHEWOLFPUP', 'BTC'],
@@ -17,6 +21,7 @@ export const Pairs = () => {
     ['BUSD', 'BTC'],
     ['MIDLGROUNDSGEARSTOKEN', 'BTC'],
     ['BUSD', 'MIDLGROUNDSGEARSTOKEN'],
+    ...COMMUNITY_PAIRS,
   ].reduce(
     (acc, symbols) => {
       acc.push({

--- a/apps/web/src/widgets/pairs/ui/Pairs.tsx
+++ b/apps/web/src/widgets/pairs/ui/Pairs.tsx
@@ -7,7 +7,7 @@ import { getAddress } from 'viem';
 import { css } from '~/styled-system/css';
 
 const COMMUNITY_PAIRS = [
-  ['MIDLRUNESTABLECOIN', 'WARTOK'],
+  ['BUSD', 'WARTOK'],
   ['WARTOK', 'BTC'],
 ];
 export const Pairs = () => {


### PR DESCRIPTION
- Introduced `COMMUNITY_PAIRS` constant with predefined token pairings.
- Updated `Pairs` widget to include `COMMUNITY_PAIRS` in tokens array.