### PR TITLE
feat: add unit tests for `useTokenBalance` with BTC balance query imp…

### DIFF
--- a/apps/web/src/features/token/api/useTokenBalance.test.tsx
+++ b/apps/web/src/features/token/api/useTokenBalance.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { Address } from 'viem';
+
+import { useTokenBalance } from './useTokenBalance';
+
+let mockIsConnected = false;
+let mockOrdAddress: string | undefined = undefined;
+
+const btcBalanceHookMock = vi.fn((..._args: any[]) => ({
+  balance: 0n,
+}));
+
+vi.mock('@midl-xyz/midl-js-react', async (importActual) => {
+  const actual = await importActual<any>();
+  return {
+    ...actual,
+    useBalance: (params: any) => btcBalanceHookMock(params),
+    useAccounts: () => ({
+      ordinalsAccount: mockOrdAddress ? { address: mockOrdAddress } : undefined,
+      isConnected: mockIsConnected,
+    }),
+    useRuneBalance: () => ({ balance: { balance: 0n } }),
+  };
+});
+
+vi.mock('@midl-xyz/midl-js-executor-react', async (importActual) => {
+  const actual = await importActual<any>();
+  return {
+    ...actual,
+    useEVMAddress: () => undefined,
+    useToken: () => ({ rune: undefined }),
+  };
+});
+
+vi.mock('wagmi', () => ({
+  useBalance: () => ({ data: { value: 0n } }),
+  useReadContracts: () => ({ data: undefined, refetch: vi.fn() }),
+}));
+
+vi.mock('@/global', () => ({ tokenList: [] }));
+
+const TEST_ADDRESS = '0x0000000000000000000000000000000000000001' as Address;
+
+describe('useTokenBalance - BTC query enabled matches isConnected', () => {
+  beforeEach(() => {
+    btcBalanceHookMock.mockClear();
+    mockIsConnected = false;
+    mockOrdAddress = undefined;
+  });
+
+  it('passes enabled=false when not connected and enabled=true after connect', () => {
+    const { rerender } = renderHook(() => useTokenBalance(TEST_ADDRESS));
+
+    expect(btcBalanceHookMock).toHaveBeenCalledTimes(1);
+    expect(btcBalanceHookMock.mock.calls[0]?.[0]).toEqual({
+      query: { enabled: false },
+    });
+
+    mockIsConnected = true;
+    rerender();
+
+    expect(btcBalanceHookMock).toHaveBeenCalledTimes(2);
+    expect(btcBalanceHookMock.mock.calls[1]?.[0]).toEqual({
+      query: { enabled: true },
+    });
+  });
+
+  it('keeps enabled=true when account changes while staying connected', () => {
+    mockIsConnected = true;
+    mockOrdAddress = 'bc1qaddr1';
+
+    const { rerender } = renderHook(() => useTokenBalance(TEST_ADDRESS));
+
+    expect(btcBalanceHookMock).toHaveBeenCalledTimes(1);
+    expect(btcBalanceHookMock.mock.calls[0]?.[0]).toEqual({
+      query: { enabled: true },
+    });
+
+    btcBalanceHookMock.mockClear();
+    mockOrdAddress = 'bc1qaddr2';
+    rerender();
+
+    expect(btcBalanceHookMock).toHaveBeenCalledTimes(1);
+    expect(btcBalanceHookMock.mock.calls[0]?.[0]).toEqual({
+      query: { enabled: true },
+    });
+  });
+});

--- a/apps/web/src/features/token/api/useTokenBalance.ts
+++ b/apps/web/src/features/token/api/useTokenBalance.ts
@@ -7,7 +7,7 @@ import {
   useRuneBalance,
 } from '@midl-xyz/midl-js-react';
 import { useMemo } from 'react';
-import { Address, erc20Abi, formatUnits, parseUnits, zeroAddress } from 'viem';
+import { Address, erc20Abi, formatUnits, zeroAddress } from 'viem';
 import { useBalance, useReadContracts } from 'wagmi';
 
 export const useTokenBalance = (
@@ -20,8 +20,14 @@ export const useTokenBalance = (
   } = {},
 ) => {
   const userAddress = useEVMAddress();
-  const { ordinalsAccount } = useAccounts();
-  const { balance: btcBalance } = useBTCBalance({});
+  const { ordinalsAccount, isConnected } = useAccounts();
+
+  const { balance: btcBalance } = useBTCBalance({
+    query: {
+      enabled: isConnected,
+    },
+  });
+
   const evmNativeTokenBalance = useBalance();
 
   const convertedBTCBalance = satoshisToWei(btcBalance);


### PR DESCRIPTION
…rovements

- Added comprehensive test coverage for `useTokenBalance`, validating BTC balance query behavior based on connection status.
- Enhanced `BTCBalance` query to dynamically enable/disable based on `isConnected` state.