### PR TITLE
fix(nav): update logo links to point to `/swap`

### DIFF
--- a/apps/web/src/app/(app-layout)/layout.tsx
+++ b/apps/web/src/app/(app-layout)/layout.tsx
@@ -43,7 +43,7 @@ export default function AppLayout({
                 justifyContent: 'space-between',
               })}
             >
-              <Link href="/">
+              <Link href="/swap">
                 <Logo />
               </Link>
               <HStack display={{ base: 'none', md: 'flex' }} gap={8} h="full">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
               justifyContent: 'space-between',
             })}
           >
-            <Link href="/">
+            <Link href="/swap">
               <Logo />
             </Link>
             <HStack display={{ base: 'none', md: 'flex' }} gap={8} h="full">


### PR DESCRIPTION
- Changed root logo links in `layout.tsx` and `page.tsx` to `/swap` instead of `/`.
https://www.notion.so/If-click-on-logo-page-freezes-25d362757c9880dba2bcc1512f45c1b7?v=254362757c98819b8dbc000cab182bf2