### PR TITLE
fix(SwapForm): reset token amount on missing swap rates

### DIFF
--- a/apps/web/src/widgets/swap-form/ui/SwapForm.tsx
+++ b/apps/web/src/widgets/swap-form/ui/SwapForm.tsx
@@ -103,6 +103,7 @@ export const SwapForm = ({
       ],
     });
     if (!swapRates) {
+      setValue('outputTokenAmount', formatUnits(0n, outputTokenInfo.decimals));
       return;
     }
 
@@ -132,6 +133,7 @@ export const SwapForm = ({
     });
 
     if (!swapRates) {
+      setValue('inputTokenAmount', formatUnits(0n, inputTokenInfo.decimals));
       return;
     }
 


### PR DESCRIPTION
https://www.notion.so/254362757c98816eaa18db14ba3bcb0d?v=254362757c9881b38afd000c1ae9b764&p=26a362757c988020be2ccffed6192858&pm=s
- Set `outputTokenAmount` to zero when `swapRates` are unavailable.
- Set `inputTokenAmount` to zero when `swapRates` are unavailable.